### PR TITLE
change dbschemaconfig to entitytypes

### DIFF
--- a/irisjsMetatag.js
+++ b/irisjsMetatag.js
@@ -70,7 +70,7 @@ iris.modules.irisjsMetatag.registerHook("hook_frontend_template", 0, function (t
 
     var entity = thisHook.context.vars.current;
 
-    var schema = iris.dbSchemaConfig[entity.entityType];
+    var schema = iris.entityTypes[entity.entityType];
 
     Object.keys(schema.fields).forEach(function(field) {
 


### PR DESCRIPTION
**bug found**

`````` "name":"iris","hostname":"chitoburst-test-iris-module-3348760","pid":5818,"level":50,"msg":"TypeError: Cannot read property 'page' of undefined\n    at Object.event (/home/ubuntu/workspace/node_modules/irisjs-metatag/irisjsMetatag.js:73:37)\n    at /home/ubuntu/workspace/node_modules/irisjs/hook.js:164:22\n    at /home/ubuntu/workspace/node_modules/irisjs/hook.js:131:16","time":"2016-06-15T08:54:23.422Z","v":0
{"name":"iris","hostname":"chitoburst-test-iris-module-3348760","pid":5818,"level":50,"msg":"Hook error","time":"2016-06-15T08:54:23.424Z","v":0} ```

**fixed** 

renamed iris.dbSchemaConfig to iris.entityTypes
``````
